### PR TITLE
支持多账号，设置CTP状态文件存储在相应账号下

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ __pycache__/
 .vs/
 x64/
 
+# PyCharm
+.idea/

--- a/vnpy_ctp/gateway/ctp_gateway.py
+++ b/vnpy_ctp/gateway/ctp_gateway.py
@@ -374,7 +374,7 @@ class CtpMdApi(MdApi):
 
         # 禁止重复发起连接，会导致异常崩溃
         if not self.connect_status:
-            path: Path = get_folder_path(self.gateway_name.lower())
+            path: Path = get_folder_path(self.gateway_name.lower() + "\\" + self.userid.lower())
             self.createFtdcMdApi((str(path) + "\\Md").encode("GBK"))
 
             self.registerFront(address)
@@ -736,7 +736,7 @@ class CtpTdApi(TdApi):
         self.appid = appid
 
         if not self.connect_status:
-            path: Path = get_folder_path(self.gateway_name.lower())
+            path: Path = get_folder_path(self.gateway_name.lower() + "\\" + self.userid.lower())
             self.createFtdcTraderApi((str(path) + "\\Td").encode("GBK"))
 
             self.subscribePrivateTopic(0)


### PR DESCRIPTION
支持多账号，设置CTP状态文件存储在相应账号下。
在单独使用vnpy_ctp时，单节点有多账号登陆需求，需要保持状态文件独立
目前vnpy系统只支持一种Gateway登陆一个账号，为今后扩展多账号，组合账号做准备