### PR TITLE
[Fix] 修复清算单中丢弃不完整GBK字符的问题

### DIFF
--- a/vnpy_ctp/api/vnctp/vnctptd/vnctptd.cpp
+++ b/vnpy_ctp/api/vnctp/vnctptd/vnctptd.cpp
@@ -4624,7 +4624,7 @@ void TdApi::processRspQrySettlementInfo(Task *task)
 		data["BrokerID"] = toUtf(task_data->BrokerID);
 		data["InvestorID"] = toUtf(task_data->InvestorID);
 		data["SequenceNo"] = task_data->SequenceNo;
-		data["Content"] = toUtf(task_data->Content);
+		data["Content"] = pybind11::bytes(task_data->Content);
 		data["AccountID"] = toUtf(task_data->AccountID);
 		data["CurrencyID"] = toUtf(task_data->CurrencyID);
 		delete task_data;


### PR DESCRIPTION
单次清算单传输可能不构成完整的一个GBK字符，这时使用toUtf会导致结尾的字符被丢弃。此处应当直接回传bytes，之后在gateway里将所有bytes统一转换成UTF。

p.s. 这个PR里面没有实现gateway的功能，期待官方的实现。