### PR TITLE
可编辑模式下无需build到api源码目录，保持源码目录干净

### DIFF
--- a/copy-wrap.py
+++ b/copy-wrap.py
@@ -1,0 +1,8 @@
+import shutil, sys, os
+try:
+    if os.path.isdir(sys.argv[1]):
+        shutil.copytree(sys.argv[1], sys.argv[2], dirs_exist_ok=True)
+    else:
+        shutil.copy2(sys.argv[1], sys.argv[2])
+except shutil.SameFileError:
+    pass

--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ if host_machine.system() == 'windows'
     'vnpy_ctp/api/vnctp',
     pybind11_include_dir,
   )
-  
+
   # 定义CTP库
   thostmduserapi_lib = cpp.find_library('thostmduserapi_se', 
                                        dirs: [lib_dir, api_dir],
@@ -65,7 +65,7 @@ if host_machine.system() == 'windows'
   thosttraderapi_lib = cpp.find_library('thosttraderapi_se', 
                                        dirs: [lib_dir, api_dir],
                                        required: true)
-                                       
+
 # 设置Mac特定编译选项
 elif host_machine.system() == 'darwin'
   # Mac编译器设置
@@ -205,15 +205,17 @@ if host_machine.system() == 'windows'
   )
 elif host_machine.system() == 'darwin'
   # 安装Mac Framework文件夹
-  install_subdir(
+  api_libs = [
     'vnpy_ctp/api/thostmduserapi_se.framework',
-    install_dir: py.get_install_dir() / 'vnpy_ctp/api'
-  )
-  
-  install_subdir(
-    'vnpy_ctp/api/thosttraderapi_se.framework',
-    install_dir: py.get_install_dir() / 'vnpy_ctp/api'
-  )
+    'vnpy_ctp/api/thosttraderapi_se.framework'
+  ]
+  foreach lib : api_libs
+    py.install_subdir(
+      lib,
+      install_dir: py.get_install_dir() / 'vnpy_ctp/api'
+    )
+  endforeach
+
 else  # Linux
   api_libs = [
     'vnpy_ctp/api/libthostmduserapi_se.so',
@@ -225,3 +227,8 @@ else  # Linux
     install_dir: py.get_install_dir() / 'vnpy_ctp/api'
   )
 endif
+
+# 复制依赖的动态库文件到build目录，此时可编辑模式能找到dll
+foreach lib : api_libs
+  run_command(python_cmd, meson.current_source_dir() / 'copy-wrap.py', meson.current_source_dir() /  lib, meson.project_build_root(), check: true)
+endforeach


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容
可编辑模式安装下无需build到api文件夹，保持源码目录干净
此时以可编辑模式安装只需要 pip install -e . --no-build-isolation

## 相关的Issue号（如有）

Close #