### PR TITLE
fix(mac): make ctp bindings compatible with bundled mac headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,9 +16,8 @@ fs = import('fs')
 py = import('python').find_installation(pure: false)
 py_dep = py.dependency()
 
-# 获取pybind11路径
-python_cmd = host_machine.system() == 'windows' ? 'python' : 'python3'
-pybind11_include_dir = run_command(python_cmd, '-c', 'import pybind11; print(pybind11.get_include())', check: true).stdout().strip()
+# 获取pybind11路径（使用当前Meson识别的Python解释器）
+pybind11_include_dir = run_command(py, '-c', 'import pybind11; print(pybind11.get_include())', check: true).stdout().strip()
 message('使用pybind11路径: ' + pybind11_include_dir)
 
 # 获取编译器信息
@@ -33,6 +32,10 @@ thostmduserapi_lib = []
 thosttraderapi_lib = []
 extra_cpp_args = []
 extra_link_args = []
+md_link_args = []
+td_link_args = []
+install_rpath_value = '$ORIGIN'
+build_rpath_value = '$ORIGIN'
 
 # 初始化库变量
 thostmduserapi_lib = []
@@ -40,7 +43,6 @@ thosttraderapi_lib = []
 
 # 初始化其他编译选项
 extra_link_args = []
-install_rpath_value = ''
 
 # 设置Windows特定编译选项
 if host_machine.system() == 'windows'
@@ -55,7 +57,6 @@ if host_machine.system() == 'windows'
   include_dirs = include_directories(
     'vnpy_ctp/api/include',
     'vnpy_ctp/api/vnctp',
-    pybind11_include_dir,
   )
   
   # 定义CTP库
@@ -77,36 +78,29 @@ elif host_machine.system() == 'darwin'
   # 设置链接参数，包括@rpath到@loader_path的修改
   extra_link_args = [
     '-mmacosx-version-min=10.12',
-    '-Wl,-rpath,@loader_path',
   ]
   
   # 设置库目录
-  lib_dir = meson.current_source_dir() / 'vnpy_ctp/api/libs'
+  lib_dir = meson.current_source_dir() / 'vnpy_ctp/api'
   api_dir = meson.current_source_dir() / 'vnpy_ctp/api'
+  install_rpath_value = '@loader_path'
+  build_rpath_value = api_dir
 
   # 设置include目录
   include_dirs = include_directories(
     'vnpy_ctp/api/include/mac',
     'vnpy_ctp/api/vnctp',
-    pybind11_include_dir,
   )
   
-  # 定义Mac Framework依赖
-  thostmduserapi_lib = declare_dependency(
-    dependencies: [py_dep],
-    link_args: [
-      '-F', meson.current_source_dir() / 'vnpy_ctp/api',
-      '-framework', 'thostmduserapi_se'
-    ]
-  )
-  
-  thosttraderapi_lib = declare_dependency(
-    dependencies: [py_dep],
-    link_args: [
-      '-F', meson.current_source_dir() / 'vnpy_ctp/api',
-      '-framework', 'thosttraderapi_se'
-    ]
-  )
+  md_link_args = extra_link_args + [
+    '-F', api_dir,
+    '-framework', 'thostmduserapi_se',
+  ]
+
+  td_link_args = extra_link_args + [
+    '-F', api_dir,
+    '-framework', 'thosttraderapi_se',
+  ]
 
 # 设置Linux特定编译选项
 else  # Linux
@@ -129,7 +123,6 @@ else  # Linux
   include_dirs = include_directories(
     'vnpy_ctp/api/include',
     'vnpy_ctp/api/vnctp',
-    pybind11_include_dir,
   )
   
   # 定义CTP库
@@ -141,6 +134,22 @@ else  # Linux
                                        required: true)
 endif
 
+if host_machine.system() != 'darwin'
+  md_link_args = extra_link_args + [
+    '-L' + lib_dir,
+    '-lthostmduserapi_se',
+    '-Wl,-rpath,$ORIGIN'
+  ]
+
+  td_link_args = extra_link_args + [
+    '-L' + lib_dir,
+    '-lthosttraderapi_se',
+    '-Wl,-rpath,$ORIGIN'
+  ]
+endif
+
+extra_cpp_args += ['-I' + pybind11_include_dir]
+
 # 创建MD模块扩展
 md_module = py.extension_module(
   'vnctpmd',
@@ -148,13 +157,10 @@ md_module = py.extension_module(
   include_directories: include_dirs,
   dependencies: [py_dep],
   cpp_args: extra_cpp_args,
-  link_args: extra_link_args + [
-    '-L' + lib_dir,
-    '-lthostmduserapi_se',
-    '-Wl,-rpath,$ORIGIN'
-  ],
+  link_args: md_link_args,
   install: true,
-  install_rpath: '$ORIGIN',
+  build_rpath: build_rpath_value,
+  install_rpath: install_rpath_value,
   subdir: 'vnpy_ctp/api'
 )
 
@@ -165,13 +171,10 @@ td_module = py.extension_module(
   include_directories: include_dirs,
   dependencies: [py_dep],
   cpp_args: extra_cpp_args,
-  link_args: extra_link_args + [
-    '-L' + lib_dir,
-    '-lthosttraderapi_se',
-    '-Wl,-rpath,$ORIGIN'
-  ],
+  link_args: td_link_args,
   install: true,
-  install_rpath: '$ORIGIN',
+  build_rpath: build_rpath_value,
+  install_rpath: install_rpath_value,
   subdir: 'vnpy_ctp/api'
 )
 

--- a/vnpy_ctp/api/vnctp/vnctpmd/vnctpmd.cpp
+++ b/vnpy_ctp/api/vnctp/vnctpmd/vnctpmd.cpp
@@ -358,10 +358,12 @@ void MdApi::processRspUserLogin(Task *task)
 		data["INETime"] = toUtf(task_data->INETime);
 		data["SysVersion"] = toUtf(task_data->SysVersion);
 		data["GFEXTime"] = toUtf(task_data->GFEXTime);
+#if !defined(__APPLE__)
 		data["LoginDRIdentityID"] = task_data->LoginDRIdentityID;
 		data["UserDRIdentityID"] = task_data->UserDRIdentityID;
 		data["LastLoginTime"] = toUtf(task_data->LastLoginTime);
 		data["ReserveInfo"] = toUtf(task_data->ReserveInfo);
+#endif
 		delete task_data;
 	}
 	dict error;
@@ -611,7 +613,12 @@ void MdApi::processRtnForQuoteRsp(Task *task)
 
 void MdApi::createFtdcMdApi(string pszFlowPath, bool bIsProductionMode)
 {
+#if defined(__APPLE__)
+	(void)bIsProductionMode;
+	this->api = CThostFtdcMdApi::CreateFtdcMdApi(pszFlowPath.c_str(), false, false);
+#else
 	this->api = CThostFtdcMdApi::CreateFtdcMdApi(pszFlowPath.c_str(), false, false, bIsProductionMode);
+#endif
 	this->api->RegisterSpi(this);
 };
 

--- a/vnpy_ctp/api/vnctp/vnctptd/vnctptd.cpp
+++ b/vnpy_ctp/api/vnctp/vnctptd/vnctptd.cpp
@@ -2977,7 +2977,7 @@ void TdApi::OnRspQryInvestorProdRULEMargin(CThostFtdcInvestorProdRULEMarginField
 	this->task_queue.push(task);
 };
 
-void TdApi::OnRspQryInvestorPortfSetting(CThostFtdcInvestorPortfSettingField *pInvestorPortfSetting, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast) 
+void TdApi::OnRspQryInvestorPortfSetting(CThostFtdcInvestorPortfSettingField *pInvestorPortfSetting, CThostFtdcRspInfoField *pRspInfo, int nRequestID, bool bIsLast)
 {
 	Task task = Task();
 	task.task_name = ONRSPQRYINVESTORPORTFSETTING;
@@ -2998,6 +2998,8 @@ void TdApi::OnRspQryInvestorPortfSetting(CThostFtdcInvestorPortfSettingField *pI
 	this->task_queue.push(task);
 };
 
+// These callbacks rely on newer CTP structs absent in the macOS headers bundled with this project.
+#if !defined(__APPLE__)
 void TdApi::OnRspQryInvestorInfoCommRec(CThostFtdcInvestorInfoCommRecField* pInvestorInfoCommRec, CThostFtdcRspInfoField* pRspInfo, int nRequestID, bool bIsLast)
 {
 	Task task = Task();
@@ -3153,6 +3155,7 @@ void TdApi::OnRspQryOffsetSetting(CThostFtdcOffsetSettingField* pOffsetSetting, 
 	task.task_last = bIsLast;
 	this->task_queue.push(task);
 };
+#endif
 
 ///-------------------------------------------------------------------------------------
 ///工作线程从队列中取出数据，转化为python对象后，进行推送
@@ -4104,6 +4107,7 @@ void TdApi::processTask()
 				break;
 			}
 
+#if !defined(__APPLE__)
 			case ONRSPQRYINVESTORINFOCOMMREC:
 			{
 				this->processRspQryInvestorInfoCommRec(&task);
@@ -4151,7 +4155,8 @@ void TdApi::processTask()
 				this->processRspQryOffsetSetting(&task);
 				break;
 			}
-            };
+#endif
+			};
         }
     }
     catch (const TerminatedError&)
@@ -4224,10 +4229,12 @@ void TdApi::processRspUserLogin(Task *task)
 		data["INETime"] = toUtf(task_data->INETime);
 		data["SysVersion"] = toUtf(task_data->SysVersion);
 		data["GFEXTime"] = toUtf(task_data->GFEXTime);
+#if !defined(__APPLE__)
 		data["LoginDRIdentityID"] = task_data->LoginDRIdentityID;
 		data["UserDRIdentityID"] = task_data->UserDRIdentityID;
 		data["LastLoginTime"] = toUtf(task_data->LastLoginTime);
 		data["ReserveInfo"] = toUtf(task_data->ReserveInfo);
+#endif
 		delete task_data;
 	}
 	dict error;
@@ -5222,7 +5229,9 @@ void TdApi::processRspQryInvestorPosition(Task *task)
 		data["TasPosition"] = task_data->TasPosition;
 		data["TasPositionCost"] = task_data->TasPositionCost;
 		data["InstrumentID"] = toUtf(task_data->InstrumentID);
+#if !defined(__APPLE__)
 		data["OptionValue"] = task_data->OptionValue;
+#endif
 		delete task_data;
 	}
 	dict error;
@@ -5292,7 +5301,9 @@ void TdApi::processRspQryTradingAccount(Task *task)
 		data["BizType"] = task_data->BizType;
 		data["FrozenSwap"] = task_data->FrozenSwap;
 		data["RemainSwap"] = task_data->RemainSwap;
+#if !defined(__APPLE__)
 		data["OptionValue"] = task_data->OptionValue;
+#endif
 		delete task_data;
 	}
 	dict error;
@@ -6315,7 +6326,9 @@ void TdApi::processRspQrySecAgentTradingAccount(Task *task)
 		data["BizType"] = task_data->BizType;
 		data["FrozenSwap"] = task_data->FrozenSwap;
 		data["RemainSwap"] = task_data->RemainSwap;
+#if !defined(__APPLE__)
 		data["OptionValue"] = task_data->OptionValue;
+#endif
 		delete task_data;
 	}
 	dict error;
@@ -10450,6 +10463,7 @@ void TdApi::processRspQryInvestorPortfSetting(Task *task)
 	this->onRspQryInvestorPortfSetting(data, error, task->task_id, task->task_last);
 };
 
+#if !defined(__APPLE__)
 void TdApi::processRspQryInvestorInfoCommRec(Task* task)
 {
 	gil_scoped_acquire acquire;
@@ -10750,6 +10764,7 @@ void TdApi::processRspQryOffsetSetting(Task* task)
 	}
 	this->onRspQryOffsetSetting(data, error, task->task_id, task->task_last);
 };
+#endif
 
 ///-------------------------------------------------------------------------------------
 ///主动函数
@@ -10757,7 +10772,12 @@ void TdApi::processRspQryOffsetSetting(Task* task)
 
 void TdApi::createFtdcTraderApi(string pszFlowPath, bool bIsProductionMode)
 {
+#if defined(__APPLE__)
+    (void)bIsProductionMode;
+    this->api = CThostFtdcTraderApi::CreateFtdcTraderApi(pszFlowPath.c_str());
+#else
     this->api = CThostFtdcTraderApi::CreateFtdcTraderApi(pszFlowPath.c_str(), bIsProductionMode);
+#endif
     this->api->RegisterSpi(this);
 };
 
@@ -10884,6 +10904,11 @@ int TdApi::submitUserSystemInfo(const dict& req)
 
 int TdApi::registerWechatUserSystemInfo(const dict& req)
 {
+#if defined(__APPLE__)
+	(void)req;
+	// Wechat-specific API is not exposed by bundled macOS CTP headers.
+	return -1;
+#else
 	CThostFtdcWechatUserSystemInfoField myreq = CThostFtdcWechatUserSystemInfoField();
 	memset(&myreq, 0, sizeof(myreq));
 	getString(req, "BrokerID", myreq.BrokerID);
@@ -10897,10 +10922,16 @@ int TdApi::registerWechatUserSystemInfo(const dict& req)
 	getString(req, "ClientLoginRemark", myreq.ClientLoginRemark);
 	int i = this->api->RegisterWechatUserSystemInfo(&myreq);
 	return i;
+#endif
 };
 
 int TdApi::submitWechatUserSystemInfo(const dict& req)
 {
+#if defined(__APPLE__)
+	(void)req;
+	// Wechat-specific API is not exposed by bundled macOS CTP headers.
+	return -1;
+#else
 	CThostFtdcWechatUserSystemInfoField myreq = CThostFtdcWechatUserSystemInfoField();
 	memset(&myreq, 0, sizeof(myreq));
 	getString(req, "BrokerID", myreq.BrokerID);
@@ -10914,6 +10945,7 @@ int TdApi::submitWechatUserSystemInfo(const dict& req)
 	getString(req, "ClientLoginRemark", myreq.ClientLoginRemark);
 	int i = this->api->SubmitWechatUserSystemInfo(&myreq);
 	return i;
+#endif
 };
 
 int TdApi::reqAuthenticate(const dict &req, int reqid)
@@ -11646,6 +11678,12 @@ int TdApi::reqQryInstrumentCommissionRate(const dict &req, int reqid)
 
 int TdApi::reqQryUserSession(const dict& req, int reqid)
 {
+#if defined(__APPLE__)
+	(void)req;
+	(void)reqid;
+	// API method is not available in bundled macOS CTP headers.
+	return -1;
+#else
 	CThostFtdcQryUserSessionField myreq = CThostFtdcQryUserSessionField();
 	memset(&myreq, 0, sizeof(myreq));
 	getInt(req, "FrontID", &myreq.FrontID);
@@ -11654,6 +11692,7 @@ int TdApi::reqQryUserSession(const dict& req, int reqid)
 	getString(req, "UserID", myreq.UserID);
 	int i = this->api->ReqQryUserSession(&myreq, reqid);
 	return i;
+#endif
 };
 
 int TdApi::reqQryExchange(const dict &req, int reqid)
@@ -12672,6 +12711,12 @@ int TdApi::reqQryInvestorPortfSetting(const dict &req, int reqid)
 
 int TdApi::reqQryInvestorInfoCommRec(const dict& req, int reqid)
 {
+#if defined(__APPLE__)
+	(void)req;
+	(void)reqid;
+	// API method/struct is not available in bundled macOS CTP headers.
+	return -1;
+#else
 	CThostFtdcQryInvestorInfoCommRecField myreq = CThostFtdcQryInvestorInfoCommRecField();
 	memset(&myreq, 0, sizeof(myreq));
 	getString(req, "InvestorID", myreq.InvestorID);
@@ -12679,19 +12724,33 @@ int TdApi::reqQryInvestorInfoCommRec(const dict& req, int reqid)
 	getString(req, "BrokerID", myreq.BrokerID);
 	int i = this->api->ReqQryInvestorInfoCommRec(&myreq, reqid);
 	return i;
+#endif
 };
 
 int TdApi::reqQryCombLeg(const dict& req, int reqid)
 {
+#if defined(__APPLE__)
+	(void)req;
+	(void)reqid;
+	// API method/struct is not available in bundled macOS CTP headers.
+	return -1;
+#else
 	CThostFtdcQryCombLegField myreq = CThostFtdcQryCombLegField();
 	memset(&myreq, 0, sizeof(myreq));
 	getString(req, "LegInstrumentID", myreq.LegInstrumentID);
 	int i = this->api->ReqQryCombLeg(&myreq, reqid);
 	return i;
+#endif
 };
 
 int TdApi::reqOffsetSetting(const dict& req, int reqid)
 {
+#if defined(__APPLE__)
+	(void)req;
+	(void)reqid;
+	// API method/struct is not available in bundled macOS CTP headers.
+	return -1;
+#else
 	CThostFtdcInputOffsetSettingField myreq = CThostFtdcInputOffsetSettingField();
 	memset(&myreq, 0, sizeof(myreq));
 	getString(req, "BrokerID", myreq.BrokerID);
@@ -12709,10 +12768,17 @@ int TdApi::reqOffsetSetting(const dict& req, int reqid)
 	getString(req, "MacAddress", myreq.MacAddress);
 	int i = this->api->ReqOffsetSetting(&myreq, reqid);
 	return i;
+#endif
 };
 
 int TdApi::reqCancelOffsetSetting(const dict& req, int reqid)
 {
+#if defined(__APPLE__)
+	(void)req;
+	(void)reqid;
+	// API method/struct is not available in bundled macOS CTP headers.
+	return -1;
+#else
 	CThostFtdcInputOffsetSettingField myreq = CThostFtdcInputOffsetSettingField();
 	memset(&myreq, 0, sizeof(myreq));
 	getString(req, "BrokerID", myreq.BrokerID);
@@ -12730,10 +12796,17 @@ int TdApi::reqCancelOffsetSetting(const dict& req, int reqid)
 	getString(req, "MacAddress", myreq.MacAddress);
 	int i = this->api->ReqCancelOffsetSetting(&myreq, reqid);
 	return i;
+#endif
 };
 
 int TdApi::reqQryOffsetSetting(const dict& req, int reqid)
 {
+#if defined(__APPLE__)
+	(void)req;
+	(void)reqid;
+	// API method/struct is not available in bundled macOS CTP headers.
+	return -1;
+#else
 	CThostFtdcQryOffsetSettingField myreq = CThostFtdcQryOffsetSettingField();
 	memset(&myreq, 0, sizeof(myreq));
 	getString(req, "BrokerID", myreq.BrokerID);
@@ -12742,6 +12815,7 @@ int TdApi::reqQryOffsetSetting(const dict& req, int reqid)
 	getChar(req, "OffsetType", &myreq.OffsetType);
 	int i = this->api->ReqQryOffsetSetting(&myreq, reqid);
 	return i;
+#endif
 };
 
 ///-------------------------------------------------------------------------------------

--- a/vnpy_ctp/api/vnctp/vnctptd/vnctptd.h
+++ b/vnpy_ctp/api/vnctp/vnctptd/vnctptd.h
@@ -682,6 +682,7 @@ public:
 	///投资者新型组合保证金开关查询响应
 	virtual void OnRspQryInvestorPortfSetting(CThostFtdcInvestorPortfSettingField* pInvestorPortfSetting, CThostFtdcRspInfoField* pRspInfo, int nRequestID, bool bIsLast);
 
+#if !defined(__APPLE__)
 	///投资者申报费阶梯收取记录查询响应
 	virtual void OnRspQryInvestorInfoCommRec(CThostFtdcInvestorInfoCommRecField* pInvestorInfoCommRec, CThostFtdcRspInfoField* pRspInfo, int nRequestID, bool bIsLast);
 
@@ -705,6 +706,7 @@ public:
 
 	///投资者对冲设置查询响应
 	virtual void OnRspQryOffsetSetting(CThostFtdcOffsetSettingField* pOffsetSetting, CThostFtdcRspInfoField* pRspInfo, int nRequestID, bool bIsLast);
+#endif
     //-------------------------------------------------------------------------------------
     //task：任务
     //-------------------------------------------------------------------------------------


### PR DESCRIPTION
修改原因/目的
为解决 vnpy_ctp 在 macOS（项目内置 mac CTP 头文件与 framework）下无法稳定编译与导入的问题，消除参数签名不一致、结构体字段缺失、接口缺失以及 editable 安装时动态库加载失败等兼容性问题。
